### PR TITLE
Update maximum cookiecutter version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - arrow <0.14.0
     - python
     - pytest >=3.3.0,<6.0.0
-    - cookiecutter >=1.4.0,<=1.6.0
+    - cookiecutter >=1.4.0,<1.8.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   preserve_egg_dir: true
 


### PR DESCRIPTION
https://github.com/hackebrot/pytest-cookies/blob/0.5.0/setup.py allows cookiecutter=1.7.0

Should also allow bug fix releases